### PR TITLE
パンくずリスト作成

### DIFF
--- a/layout/theme.liquid
+++ b/layout/theme.liquid
@@ -377,6 +377,9 @@ body {
       class="content-for-layout focus-none"
       role="main"
       tabindex="-1">
+      <div class="page-width">
+        {% render 'breadcrumb' %}
+      </div>
       {{ content_for_layout }}
     </main>
 

--- a/snippets/breadcrumb.liquid
+++ b/snippets/breadcrumb.liquid
@@ -1,0 +1,158 @@
+<style>
+  .breadcrumbs {
+    margin: 0 0 2em;
+  }
+
+  .breadcrumbs__list {
+    list-style-type: none;
+    margin: 0;
+    padding: 0;
+  }
+
+  .breadcrumbs__item {
+    display: inline-block;
+  }
+
+  .breadcrumbs__item:not(:last-child):after {
+    border-style: solid;
+    border-width: 0.10em 0.10em 0 0;
+    content: '';
+    display: inline-block;
+    height: 0.20em;
+    margin: 0 0.20em;
+    position: relative;
+    transform: rotate(45deg);
+    vertical-align: middle;
+    width: 0.20em;
+  }
+
+  .breadcrumbs__link {
+    text-decoration: underline;
+  }
+
+  .breadcrumbs__link[aria-current="page"] {
+    color: inherit;
+    font-weight: normal;
+    text-decoration: none;
+  }
+
+  .breadcrumbs__link[aria-current="page"]:hover,
+  .breadcrumbs__link[aria-current="page"]:focus {
+    text-decoration: underline;
+  }
+</style>
+
+{%- unless template == 'index' or template == 'cart' or template == 'list-collections' or template == '404' -%}
+  {%- assign t = template | split: '.' | first -%}
+
+  <nav
+    class="breadcrumbs"
+    role="navigation"
+    aria-label="breadcrumbs">
+    <ol class="breadcrumbs__list">
+      <li class="breadcrumbs__item">
+        <a class="breadcrumbs__link" href="/">Home</a>
+      </li>
+      {%- case t -%}
+        {%- when 'page' -%}
+          <li class="breadcrumbs__item">
+            <a
+              class="breadcrumbs__link"
+              href="{{ page.url }}"
+              aria-current="page">{{ page.title }}</a>
+          </li>
+        {%- when 'product' -%}
+          {%- if collection and collection.metafields.custom.main_collection -%}
+            {% assign main_collection = collections[collection.metafields.custom.main_collection] %}
+            {% if main_collection.url %}
+              <li class="breadcrumbs__item">
+                <a
+                  class="breadcrumbs__link"
+                  href="{{ pmain_collection.url }}"
+                  aria-current="page">{{ main_collection.title }}</a>
+              </li>
+              {{ collection.title | link_to: collection.url }}
+            {% endif %}
+          {%- elsif collection.url -%}
+            <li class="breadcrumbs__item">
+              {{ collection.title | link_to: collection.url }}
+            </li>
+          {%- endif -%}
+          <li class="breadcrumbs__item">
+            <a
+              class="breadcrumbs__link"
+              href="{{ product.url }}"
+              aria-current="page">{{ product.title }}</a>
+          </li>
+        {%- when 'collection' and collection.handle -%}
+          {% if collection.metafields.custom.main_collection %}
+            {% assign main_collection = collections[collection.metafields.custom.main_collection] %}
+            {% if main_collection.url %}
+              <li class="breadcrumbs__item">
+                <a
+                  class="breadcrumbs__link"
+                  href="{{ pmain_collection.url }}"
+                  aria-current="page">{{ main_collection.title }}</a>
+              </li>
+            {% endif %}
+          {% endif %}
+          {%- if current_tags -%}
+            <li class="breadcrumbs__item">
+              {{ collection.title | link_to: collection.url }}
+            </li>
+            <li class="breadcrumbs__item">
+              {%- capture tag_url -%}{{ collection.url }}/{{ current_tags | join: "+"}}{%- endcapture -%}
+              <a
+                class="breadcrumbs__link"
+                href="{{ tag_url }}"
+                aria-current="page">{{ current_tags | join: " + " }}</a>
+            </li>
+          {%- else -%}
+            <li class="breadcrumbs__item">
+              <a
+                class="breadcrumbs__link"
+                href="{{ collection.url }}"
+                aria-current="page">{{ collection.title }}</a>
+            </li>
+          {%- endif -%}
+        {%- when 'blog' -%}
+          {%- if current_tags -%}
+            <li class="breadcrumbs__item">
+              {{ blog.title | link_to: blog.url }}
+            </li>
+            <li class="breadcrumbs__item">
+              {%- capture tag_url -%}{{blog.url}}/tagged/{{ current_tags | join: "+" }}{%- endcapture -%}
+              <a
+                class="breadcrumbs__link"
+                href="{{ tag_url }}"
+                aria-current="page">{{ current_tags | join: " + " }}</a>
+            </li>
+          {%- else -%}
+            <li class="breadcrumbs__item">
+              <a
+                class="breadcrumbs__link"
+                href="{{ blog.url }}"
+                aria-current="page">{{ blog.title }}</a>
+            </li>
+          {%- endif -%}
+        {%- when 'article' -%}
+          <li class="breadcrumbs__item">
+            {{ blog.title | link_to: blog.url }}
+          </li>
+          <li class="breadcrumbs__item">
+            <a
+              class="breadcrumbs__link"
+              href="{{ article.url }}"
+              aria-current="page">{{ article.title }}</a>
+          </li>
+        {%- else -%}
+          <li class="breadcrumbs__item">
+            <a
+              class="breadcrumbs__link"
+              href="{{ request.path }}"
+              aria-current="page">{{ page_title }}</a>
+          </li>
+      {%- endcase -%}
+    </ol>
+  </nav>
+{%- endunless -%}

--- a/snippets/card-product.liquid
+++ b/snippets/card-product.liquid
@@ -115,7 +115,7 @@
               {% endif %}
             >
               <a
-                href="{{ card_product.url }}"
+                href="{{ card_product.url |  within: collection }}"
                 id="StandardCardNoMediaLink-{{ section_id }}-{{ card_product.id }}"
                 class="full-unstyled-link"
                 aria-labelledby="StandardCardNoMediaLink-{{ section_id }}-{{ card_product.id }} NoMediaStandardBadge-{{ section_id }}-{{ card_product.id }}"
@@ -166,7 +166,7 @@
             {% endif %}
           >
             <a
-              href="{{ card_product.url }}"
+              href="{{ card_product.url |  within: collection }}"
               id="CardLink-{{ section_id }}-{{ card_product.id }}"
               class="full-unstyled-link"
               aria-labelledby="CardLink-{{ section_id }}-{{ card_product.id }} Badge-{{ section_id }}-{{ card_product.id }}"


### PR DESCRIPTION
【パンくずリスト作成】

・スニペットにbreadcrumb.liquid作成
（shopify提供のBreadcrumb navigationコード貼り付け）

・theme.liquidにrenderで読み込み

・card-product.liquidのaタグを修正
href="{{ card_product.url |  within: collection }}"

商品ページでコレクション名も表示できるように実装